### PR TITLE
fix: 修复jsx无法解析

### DIFF
--- a/modules/spaas-application/pages/application-type/index.vue
+++ b/modules/spaas-application/pages/application-type/index.vue
@@ -1,10 +1,4 @@
-<template>
-  <div class="page">
-    测试pont
-  </div>
-</template>
-
-<script lang="ts">
+<script lang="tsx">
 import { Vue, Component, Emit } from 'vue-property-decorator'
 
 @Component({})
@@ -20,6 +14,10 @@ export default class AppType extends Vue {
         }),
       '11'
     )
+  }
+
+  render() {
+    return <div>22</div>
   }
 }
 </script>

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
 		"stylelint-config-prettier": "^5.2.0",
 		"stylelint-config-standard": "^18.2.0",
 		"svg-sprite-loader": "^4.1.6",
-		"ts-loader": "^7.0.1",
+		"ts-loader": "6.2.1",
 		"ts-node": "^8.9.0"
 	},
 	"husky": {

--- a/ts.md
+++ b/ts.md
@@ -1,13 +1,13 @@
 ### nuxt配置ts
 
-1.安装所需插件
+### 1.安装所需插件
 
 - yarn add -D @nuxt/typescript ts-node @types/node @nuxt/typescript-build @nuxt/types @nuxt/typescript-runtime
 - yarn add  vue-property-decorator
 
-2.[ts语法糖](https://github.com/kaorun343/vue-property-decorator)
+### 2.[ts语法糖](https://github.com/kaorun343/vue-property-decorator)
 
-3.在 nuxt.config.js 文件中配置 ts 的 loader
+### 3.在 nuxt.config.js 文件中配置 ts 的 loader
 ```js
 {
     test: /\.ts$/,
@@ -27,11 +27,11 @@
 ### 引入ts问题
 
 
-1.tslint是否需要加？
+#### 1.tslint是否需要加？
  
   暂定
   
-2.vue-property-decorator 与@vue/composition-api 对比？
+#### 2.vue-property-decorator 与@vue/composition-api 对比？
 
 
 >区别：
@@ -75,26 +75,33 @@ vue-property-decorator 优点
 综合以上描述,故使用vue-property-decorator
 
 
+### vue-property-decorator使用教程
+
+[《Vue + TS 语法对照表》](https://deepexi.yuque.com/docs/share/ee3669f4-1f96-4c37-851f-9bf0931971df?#（密码：rqgw）)
+
+
 ### FAQ：
 
-1.typscript中是无法识别非代码资源
+#### 1.typscript中是无法识别非代码资源
  
  参考连接：[typscript中是无法识别非代码资源](https://www.cnblogs.com/chen-cong/p/10445635.html)
 
  解决方法： declare module 'xxx'
 
-2.当引入外部文件时，记得声明文件。以防出现错误
+#### 2.当引入外部文件时，记得声明文件。以防出现错误
 
-3.Property 'validate' does not exist on type 'Element | Element[] | Vue | Vue[]'. Property 'valid...
+#### 3.Property 'validate' does not exist on type 'Element | Element[] | Vue | Vue[]'. Property 'valid...
+
 [参考](https://www.jianshu.com/p/36bd22333a70)
 
-4.Property '$message' does not exist on type 
+#### 4.Property '$message' does not exist on type 
+
 参考:
 ```js
 this['$message']
 ```
 
-5. 当使用lang="tsx"的时候，代码写的没有问题,但是页面没有渲染出来,那么检查下是否写了`@Component({})`
+#### 5. 当使用lang="tsx"的时候，代码写的没有问题,但是页面没有渲染出来,那么检查下是否写了`@Component({})`
 
 ``` js
 <script lang="tsx">
@@ -109,18 +116,48 @@ export default class Test extends Vue {
 }
 </script>
 ```
-6.this.$refs写法
+
+#### 6.this.$refs写法
+
 ``` js
 1.(this.$ref[xxx] as any)
 2.this.$refs[xx]
 ```
 
-7. [typescript如何导入JSON文件](https://www.jianshu.com/p/6405e67c53e6)
+#### 7. [typescript如何导入JSON文件](https://www.jianshu.com/p/6405e67c53e6)
+
+#### 8.TSX渲染Syntax Error: Unterminated regular expression
+
+``` js
+
+ error  in ./src/views/Home.vue?vue&type=script&lang=tsx
+
+Syntax Error: Unterminated regular expression (13:35)
+  render() {
+    render: (h) => dddd < /div>   
+  }
+```
+##### 如何解决?
+
+- 前言
+
+经测试发现是因为ts-loader版本问题，故将`ts-loader` 强锁至`6.2.1` 优雅降级
+
+##### 排查错误连接
+
+1.[<script lang="tsx"> Compilation error](https://github.com/vuejs/vue-cli/issues/1399)
+
+2.[support .ts/.tsx files in pages/components](https://github.com/nuxt/nuxt.js/issues/3256)
 
 
-### 参考链接:
+
+### Vue + TS参考链接:
 1.https://www.zhihu.com/question/64147199/answer/674547048
+
 2.https://cloud.tencent.com/developer/article/1561521
+
 3.https://qiita.com/nrslib/items/be90cc19fa3122266fd7
+
 4.https://zhuanlan.zhihu.com/p/60952007
+
 5.http://bk.jzgylm.cn/frontEnd/vue-ts/vue-ts-9.html

--- a/yarn.lock
+++ b/yarn.lock
@@ -12030,7 +12030,7 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.17, source-map-support@~0.5.10, source-map-support@~0.5.12:
+source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.10, source-map-support@~0.5.12:
   version "0.5.19"
   resolved "https://registry.npm.taobao.org/source-map-support/download/source-map-support-0.5.19.tgz?cache=0&sync_timestamp=1587719289626&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsource-map-support%2Fdownload%2Fsource-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha1-qYti+G3K9PZzmWSMCFKRq56P7WE=
@@ -12997,6 +12997,17 @@ tryer@^1.0.1:
   resolved "https://registry.npm.taobao.org/tryer/download/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha1-8shUBoALmw90yfdGW4HqrSQSUvg=
 
+ts-loader@6.2.1:
+  version "6.2.1"
+  resolved "https://registry.npm.taobao.org/ts-loader/download/ts-loader-6.2.1.tgz#67939d5772e8a8c6bdaf6277ca023a4812da02ef"
+  integrity sha1-Z5OdV3LoqMa9r2J3ygI6SBLaAu8=
+  dependencies:
+    chalk "^2.3.0"
+    enhanced-resolve "^4.0.0"
+    loader-utils "^1.0.2"
+    micromatch "^4.0.0"
+    semver "^6.0.0"
+
 ts-loader@^6.0.2, ts-loader@^6.2.2:
   version "6.2.2"
   resolved "https://registry.npm.taobao.org/ts-loader/download/ts-loader-6.2.2.tgz?cache=0&sync_timestamp=1588225293251&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fts-loader%2Fdownload%2Fts-loader-6.2.2.tgz#dffa3879b01a1a1e0a4b85e2b8421dc0dfff1c58"
@@ -13008,16 +13019,16 @@ ts-loader@^6.0.2, ts-loader@^6.2.2:
     micromatch "^4.0.0"
     semver "^6.0.0"
 
-ts-loader@^7.0.1:
-  version "7.0.2"
-  resolved "https://registry.npm.taobao.org/ts-loader/download/ts-loader-7.0.2.tgz?cache=0&sync_timestamp=1588225293251&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fts-loader%2Fdownload%2Fts-loader-7.0.2.tgz#465bc904aea4c331e9550e7c7d75dd17a0b7c24c"
-  integrity sha1-RlvJBK6kwzHpVQ58fXXdF6C3wkw=
+ts-node@8.6.2:
+  version "8.6.2"
+  resolved "https://registry.npm.taobao.org/ts-node/download/ts-node-8.6.2.tgz#7419a01391a818fbafa6f826a33c1a13e9464e35"
+  integrity sha1-dBmgE5GoGPuvpvgmozwaE+lGTjU=
   dependencies:
-    chalk "^2.3.0"
-    enhanced-resolve "^4.0.0"
-    loader-utils "^1.0.2"
-    micromatch "^4.0.0"
-    semver "^6.0.0"
+    arg "^4.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.6"
+    yn "3.1.1"
 
 ts-node@^8.9.0:
   version "8.9.1"


### PR DESCRIPTION
### 问题

jsx 无法解析

### 为什么
在ts-loader 7.0.1无法解析jsx

### 如何解决

经测试发现是因为ts-loader版本问题，故将`ts-loader` 强锁至`6.2.1` 优雅降级


### 测试用例
![image](https://user-images.githubusercontent.com/20368037/83743793-cbeb0c80-a68d-11ea-9e79-916bd9a2b280.png)
